### PR TITLE
Allow for ssl/tls connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The Nsq::Producer constructor takes the following options:
 | `topic`       | Topic to which to publish messages     |                    |
 | `nsqd`        | Host and port of the nsqd instance     | '127.0.0.1:4150'   |
 | `nsqlookupd`  | Use lookupd to automatically discover nsqds |               |
+| `ssl_context` | Optional keys and certificates for TLS connections |        |
 
 For example, if you'd like to publish messages to a single nsqd.
 
@@ -79,6 +80,19 @@ to a random nsqd instance.
 producer = Nsq::Producer.new(
   nsqlookupd: ['1.2.3.4:4161', '6.7.8.9:4161'],
   topic: 'topic-of-great-esteem'
+)
+```
+
+If you need to connect using SSL/TLS
+
+```Ruby
+producer = Nsq::Producer.new(
+  nsqlookupd: ['1.2.3.4:4161', '6.7.8.9:4161'],
+  topic: 'topic-of-great-esteem',
+  ssl_context: {
+    key: '/path/to/ssl/key.pem',
+    certificate: '/path/to/ssl/certificate.pem'
+  }
 )
 ```
 
@@ -149,6 +163,7 @@ producers when you're done with them.
 | `max_in_flight`      | Max number of messages for this consumer to have in flight at a time   | 1 |
 | `discovery_interval` | Seconds between queue discovery via nsqlookupd    | 60.0   |
 | `msg_timeout`        | Milliseconds before nsqd will timeout a message   | 60000  |
+| `ssl_context`        | Optional keys and certificates for TLS connections |       |
 
 
 For example:
@@ -160,7 +175,11 @@ consumer = Nsq::Consumer.new(
   nsqlookupd: ['127.0.0.1:4161', '4.5.6.7:4161'],
   max_in_flight: 100,
   discovery_interval: 30,
-  msg_timeout: 120_000
+  msg_timeout: 120_000,
+  ssl_context: {
+    key: '/path/to/ssl/key.pem',
+    certificate: '/path/to/ssl/certificate.pem'
+  }
 )
 ```
 
@@ -285,11 +304,11 @@ connection timeout support (0.2.29).
 - Discovery via nsqlookupd
 - Automatic reconnection to nsqd
 - Producing to all nsqd instances automatically via nsqlookupd
+- TLS
 
 
 ### Does not support
 
-- TLS
 - Compression
 - Backoff
 - Authentication

--- a/lib/nsq/client_base.rb
+++ b/lib/nsq/client_base.rb
@@ -89,7 +89,8 @@ module Nsq
       host, port = nsqd.split(':')
       connection = Connection.new({
         host: host,
-        port: port
+        port: port,
+        ssl_context: @ssl_context
       }.merge(options))
       @connections[nsqd] = connection
     end

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -24,7 +24,7 @@ module Nsq
 
     def initialize(opts = {})
       @host = opts[:host] || (raise ArgumentError, 'host is required')
-      @port = opts[:port] || (raise ArgumentError, 'host is required')
+      @port = opts[:port] || (raise ArgumentError, 'port is required')
       @queue = opts[:queue]
       @topic = opts[:topic]
       @channel = opts[:channel]

--- a/lib/nsq/connection.rb
+++ b/lib/nsq/connection.rb
@@ -30,6 +30,8 @@ module Nsq
       @channel = opts[:channel]
       @msg_timeout = opts[:msg_timeout] || 60_000 # 60s
       @max_in_flight = opts[:max_in_flight] || 1
+      @ssl_context = opts[:ssl_context]
+      validate_ssl_context! if @ssl_context
 
       if @msg_timeout < 1000
         raise ArgumentError, 'msg_timeout cannot be less than 1000. it\'s in milliseconds.'
@@ -398,5 +400,18 @@ module Nsq
     end
 
 
+    def validate_ssl_context!
+      [:key, :certificate].each do |key|
+        unless @ssl_context.has_key?(key)
+          raise ArgumentError.new "ssl_context requires a :#{key}"
+        end
+      end
+
+      [:key, :certificate, :ca_certificate].each do |key|
+        if @ssl_context[key] && !File.readable?(@ssl_context[key])
+          raise LoadError.new "ssl_context :#{key} is unreadable"
+        end
+      end
+    end
   end
 end

--- a/lib/nsq/consumer.rb
+++ b/lib/nsq/consumer.rb
@@ -17,6 +17,7 @@ module Nsq
       @max_in_flight = opts[:max_in_flight] || 1
       @discovery_interval = opts[:discovery_interval] || 60
       @msg_timeout = opts[:msg_timeout]
+      @ssl_context = opts[:ssl_context]
 
       # This is where we queue up the messages we receive from each connection
       @messages = opts[:queue] || Queue.new

--- a/lib/nsq/producer.rb
+++ b/lib/nsq/producer.rb
@@ -8,6 +8,7 @@ module Nsq
       @connections = {}
       @topic = opts[:topic]
       @discovery_interval = opts[:discovery_interval] || 60
+      @ssl_context = opts[:ssl_context]
 
       nsqlookupds = []
       if opts[:nsqlookupd]

--- a/spec/lib/nsq/connection_spec.rb
+++ b/spec/lib/nsq/connection_spec.rb
@@ -34,6 +34,51 @@ describe Nsq::Connection do
         Nsq::Connection.new(host: @nsqd.host, port: @nsqd.tcp_port, max_in_flight: 1_000_000)
       }.to raise_error
     end
+
+    context 'when an ssl_context is provided' do
+      it 'raises when a key is not provided' do
+        params = {
+          host: @nsqd.host,
+          port: @nsqd.tcp_port,
+          ssl_context: {
+            certificate: 'blank',
+          }
+        }
+
+        expect{
+          Nsq::Connection.new(params)
+        }.to raise_error ArgumentError, /key/
+      end
+
+      it 'raises when a certificate is not provided' do
+        params = {
+          host: @nsqd.host,
+          port: @nsqd.tcp_port,
+          ssl_context: {
+            key: 'blank',
+          }
+        }
+
+        expect{
+          Nsq::Connection.new(params)
+        }.to raise_error ArgumentError, /certificate/
+      end
+
+      it 'raises when the key or cert files are not readable' do
+        params = {
+          host: @nsqd.host,
+          port: @nsqd.tcp_port,
+          ssl_context: {
+            key: 'not_a_file',
+            certificate: 'not_a_file'
+          }
+        }
+
+        expect{
+          Nsq::Connection.new(params)
+        }.to raise_error LoadError, /unreadable/
+      end
+    end
   end
 
 


### PR DESCRIPTION
Reason for change
================== 
We need the ability to encrypt data that goes onto the queue and be able to connect to queues on our network that are already using ssl/tls.


Change
------
* Allow ssl_context thru producer and consumer
* Use this context in set tls_v1 feature flag
* Use OpenSSL to create a SSLSocket
* inline upgrading of TCPSocket to SSLSocket when ssl_context provided
* Simple Validation of the passed in ssl_context
* Fix minor error in error wording