### PR TITLE
use URI.encode_www_form_component instead of URI.escape (obsolete)

### DIFF
--- a/lib/nsq/discovery.rb
+++ b/lib/nsq/discovery.rb
@@ -70,7 +70,7 @@ module Nsq
       uri.query = "ts=#{Time.now.to_i}"
       if topic
         uri.path = '/lookup'
-        uri.query += "&topic=#{URI.escape(topic)}"
+        uri.query += "&topic=#{URI.encode_www_form_component(topic)}"
       else
         uri.path = '/nodes'
       end


### PR DESCRIPTION
URI.escape has been deprecated and obsolete for many years. Ruby 2.7 emits a warning:

```
nsq-ruby-2.3.1/lib/nsq/discovery.rb:73: warning: URI.escape is obsolete
```

Using `URI.encode_www_form_component` will properly encode the topic for the lookup query.